### PR TITLE
Fix CI error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ before_install:
   - export PATH="$HOME/.cask/bin:$PATH"
   - export PATH="$HOME/.evm/bin:$PATH"
   - evm install $EVM_EMACS --use
+  - emacs --version
   - cask
 env:
   - EVM_EMACS=emacs-24.1-bin
   - EVM_EMACS=emacs-24.2-bin
   - EVM_EMACS=emacs-24.3-bin
 script:
-  - emacs --version
   - make install test install-file-with-deps-from-marmalade install-file-with-deps-from-melpa


### PR DESCRIPTION
Update link to cask to try and fix the error on CI:

`Cask could not be bootstrapped. Try again later, or report an issue at https://github.com/cask/cask/issues`
