### PR TITLE
Force resize-mini-windows

### DIFF
--- a/org-trello.el
+++ b/org-trello.el
@@ -3118,7 +3118,8 @@ refresh(\"/proxy/admin/entities/current/\", '#current-action');
 (defun orgtrello-controller/do-install-board-and-lists ()
   "Command to install the list boards."
   (interactive)
-  (let* ((board-info        (-> (orgtrello-controller/--list-boards!)
+  (let* ((resize-mini-windows t)
+         (board-info        (-> (orgtrello-controller/--list-boards!)
                               orgtrello-controller/--id-name
                               orgtrello-controller/choose-board!))
          (chosen-board-id   (first board-info))


### PR DESCRIPTION
Hi!

I set `resize-mini-windows` to `nil` in my config file. And `org-trello/install-board-and-lists-ids` didn't work correctly.

![old](https://cloud.githubusercontent.com/assets/1789390/2565463/252b6524-b8b5-11e3-8472-dd4b619ed1e0.png)

Now it works fine.

![new](https://cloud.githubusercontent.com/assets/1789390/2565486/4b9e7386-b8b5-11e3-87a8-fcb3f7957c82.png)
