### PR TITLE
Fix - Ensure there is a newline after each description.  org-trello/org-...

### DIFF
--- a/org-trello-buffer.el
+++ b/org-trello-buffer.el
@@ -162,13 +162,13 @@ If the VALUE is nil or empty, remove such PROPERTY."
   (orgtrello-buffer/update-property-card-comments! card)
   (orgtrello-buffer/write-unknown-properties! (orgtrello-data/entity-unknown-properties card))
   (-when-let (card-desc (orgtrello-data/entity-description card))
-    (insert (format "%s\n" card-desc))))
+    (insert (format "%s" card-desc))))
 
 (defun orgtrello-buffer/write-card! (card-id card entities adjacency)
   "Write the card and its structure inside the org buffer."
   (orgtrello-buffer/write-card-header! card-id card)
+  (insert "\n")
   (-when-let (checklists (gethash card-id adjacency))
-    (insert "\n")
     (--map (orgtrello-buffer/write-checklist! it entities adjacency) checklists)))
 
 (defun orgtrello-buffer/write-entity! (entity-id entity)

--- a/test/org-trello-buffer-tests.el
+++ b/test/org-trello-buffer-tests.el
@@ -464,6 +464,68 @@ some description
      0)))
 
 (expectations
+ (expect ":PROPERTIES:
+#+PROPERTY: orgtrello-user-ardumont ardumont-id
+#+PROPERTY: orgtrello-user-dude dude-id
+:END:
+* TODO task A
+  :PROPERTIES:
+  :orgtrello-id: card-id-a
+  :orgtrello-users: ardumont,dude
+  :orgtrello-card-comments: ardumont: some comment
+  :END:
+description A
+* TODO task B
+  :PROPERTIES:
+  :orgtrello-id: card-id-b
+  :orgtrello-users: ardumont,dude
+  :orgtrello-card-comments: ardumont: some comment
+  :END:
+description B
+"
+    (orgtrello-tests/with-temp-buffer-and-return-buffer-content
+     ":PROPERTIES:
+#+PROPERTY: orgtrello-user-ardumont ardumont-id
+#+PROPERTY: orgtrello-user-dude dude-id
+:END:
+"
+     (let ()
+       (orgtrello-buffer/write-card!
+        "card-id-a"
+        (orgtrello-hash/make-properties
+         `((:keyword . "TODO")
+           (:desc . "description A")
+           (:level . ,*ORGTRELLO/CARD-LEVEL*)
+           (:name . "task A")
+           (:id . "card-id-a")
+           (:member-ids . "ardumont-id,dude-id")
+           (:comments . ,(list (orgtrello-hash/make-properties
+                                '((:comment-user . "ardumont")
+                                  (:comment-text . "some comment")))))
+           ))
+        (orgtrello-hash/make-properties `())
+        (orgtrello-hash/make-properties `())
+        )
+       (orgtrello-buffer/write-card!
+        "card-id-b"
+        (orgtrello-hash/make-properties
+         `((:keyword . "TODO")
+           (:desc . "description B")
+           (:level . ,*ORGTRELLO/CARD-LEVEL*)
+           (:name . "task B")
+           (:id . "card-id-b")
+           (:member-ids . "ardumont-id,dude-id")
+           (:comments . ,(list (orgtrello-hash/make-properties
+                                '((:comment-user . "ardumont")
+                                  (:comment-text . "some comment")))))
+           ))
+        (orgtrello-hash/make-properties `())
+        (orgtrello-hash/make-properties `())
+        ))
+     0)
+    ))
+
+(expectations
   (expect ":PROPERTIES:
 #+PROPERTY: orgtrello-user-ardumont ardumont-id
 #+PROPERTY: orgtrello-user-dude dude-id


### PR DESCRIPTION
...trello#172

I don't know enough about to emacs-lisp to make the proper fix.  This change just blindly adds a newline after each Description, so can result in extra lines between cards.
