### PR TITLE
Fix to allow syncing of arbitrary markdown

### DIFF
--- a/org-trello-buffer.el
+++ b/org-trello-buffer.el
@@ -38,6 +38,16 @@ If the VALUE is nil or empty, remove such PROPERTY."
     (orgtrello-cbx/--goto-next-checkbox)
     (1- (point))))
 
+(defun orgtrello-buffer/check-indent! (indent)
+  (let ((bol (point)))
+    (move-to-column indent)
+    (let ((indent-contents (buffer-substring-no-properties bol (point))))
+      (unless (or (= (length indent-contents) 0)
+                  (string-match "^[ \t]+$" indent-contents))
+        (setq indent 0)
+        (forward-line 0))))
+  indent)
+
 ;TODO handle fields?
 (defun orgtrello-buffer/extract-description-from-current-position! ()
   "Given the current position, extract the text content of current card."
@@ -55,12 +65,7 @@ If the VALUE is nil or empty, remove such PROPERTY."
                 (orgtrello-buffer/filter-out-properties
                   (buffer-substring-no-properties start (min end (point))))
                 lines))
-        (let ((bol (point)))
-	      (move-to-column indent)
-	      (let ((indent-contents (buffer-substring-no-properties bol (point))))
-		(unless (string-match "^[ \t]+$" indent-contents)
-		  (setq indent 0)
-		  (forward-line 0))))
+        (setq indent (orgtrello-buffer/check-indent! indent))
 	(while
           (< (point) end)
           (let ((sol (point)))
@@ -69,7 +74,7 @@ If the VALUE is nil or empty, remove such PROPERTY."
                   (cons
 		   (buffer-substring-no-properties sol (min end (point)))
 		   lines)))
-          )))
+        (setq indent (orgtrello-buffer/check-indent! indent)))))
     ;(message "Lines: %S" lines)
     (let ((result
 	   (when lines

--- a/test/org-trello-buffer-tests.el
+++ b/test/org-trello-buffer-tests.el
@@ -65,7 +65,18 @@ hello there
 :orgtrello-id: 52c945143004d4617c012528
 :END:
 - [-] LISP family   :PROPERTIES: {\"orgtrello-id\":\"52c945140a364c5226007314\"}"
-       (orgtrello-buffer/extract-description-from-current-position!))))
+       (orgtrello-buffer/extract-description-from-current-position!)))
+    (expect "One Paragraph\n\nAnother Paragraph"
+	    (orgtrello-tests/with-temp-buffer "* TODO Joy of FUN(ctional) LANGUAGES
+  DEADLINE: <2014-04-01T00:00:00.000Z>
+  :PROPERTIES:
+  :orgtrello-id: 52c945143004d4617c012528
+  :END:
+  One Paragraph
+
+  Another Paragraph
+"
+					      (orgtrello-buffer/extract-description-from-current-position!))))
 
 (expectations (desc "orgtrello-buffer/extract-description-from-current-position! - non standard org-trello properties with blanks before them.")
   (expect "hello there"


### PR DESCRIPTION
The solution is as follows:

When syncing _to_ trello we use the indent of the first line as the
indent for the entire description.

When syncing _from_ trello we add a fixed indent of 2 to the
description.  This prevents markdown syntax from being interpreted as
org-mode syntax.

Somewhat a workaround for issue #89 the markup isn't translated, but at
least it is preserved
