### PR TITLE
Minor change to allow abbreviated file path

### DIFF
--- a/org-trello-setup.el
+++ b/org-trello-setup.el
@@ -241,7 +241,7 @@ This is intended as a buffer local variable.")
   :group 'org-trello)
 
 (add-hook 'org-mode-hook (lambda ()
-                           (when (-any? (lambda (name) (string= name buffer-file-name)) org-trello-files)
+                           (when (-any? (lambda (name) (string= (expand-file-name name) buffer-file-name)) org-trello-files)
                              (org-trello-mode))))
 
 (provide 'org-trello-setup)


### PR DESCRIPTION
Hello this enhances #210 to allow abbreviated file paths like "~/Dropbox/trello-file.org" in addition to the canonical path like "/home/sutram/Dropbox/trello-file.org"
