### PR TITLE
Fix parsing of username from comments

### DIFF
--- a/org-trello-data.el
+++ b/org-trello-data.el
@@ -190,7 +190,7 @@ SIZE is a useless parameter, only here to satisfy an implementation detail."
               (orgtrello-data-put-entity-comment-id   (assoc-default 'id it))
               (orgtrello-data-put-entity-comment-text (->> it (assoc-default 'data) (assoc-default 'text)))
               (orgtrello-data-put-entity-comment-date (assoc-default 'date it))
-              (orgtrello-data-put-entity-comment-user (->> it car (assoc-default 'username))))
+              (orgtrello-data-put-entity-comment-user (->> it (assoc-default 'memberCreator) (assoc-default 'username))))
          data))
 
 (defun orgtrello-data-parse-data (entities)

--- a/test/org-trello-data-test.el
+++ b/test/org-trello-data-test.el
@@ -422,6 +422,32 @@
                                 (idMemberCreator . "4f2baa2f72b7c1293501cad3")
                                 (id . "532d7441852414f343560757"))])
 
+(defvar alternative-data-to-test '[((id . "566")
+                                    (idMemberCreator . "52f")
+                                    (data
+                                     (list
+                                      (name . "ToDo")
+                                      (id . "561"))
+                                     (board
+                                      (shortLink . "wLd")
+                                      (name . "Working title")
+                                      (id . "562"))
+                                     (card
+                                      (shortLink . "cIZ")
+                                      (idShort . 16)
+                                      (name . "Figure out a name")
+                                      (id . "563"))
+                                     (text . "Comment 5"))
+                                    (type . "commentCard")
+                                    (date . "2015-12-09T14:05:04.685Z")
+                                    (memberCreator
+                                     (id . "52f")
+                                     (avatarHash . "5e5")
+                                     (fullName . "Martin")
+                                     (initials . "M")
+                                     (username . "redacted")))]
+)
+
 (ert-deftest test-orgtrello-data--parse-actions ()
   (should (orgtrello-tests-hash-equal
            (orgtrello-hash-make-properties '((:comment-id . "532d7447b247e3d24f365309")
@@ -434,7 +460,13 @@
                                              (:comment-text . "comment 3")
                                              (:comment-date . "2014-03-22T11:30:09.927Z")
                                              (:comment-user . "ardumont")))
-           (cadr (orgtrello-data--parse-actions partial-data-to-test)))))
+           (cadr (orgtrello-data--parse-actions partial-data-to-test))))
+  (should (orgtrello-tests-hash-equal
+           (orgtrello-hash-make-properties '((:comment-id . "566")
+                                             (:comment-text . "Comment 5")
+                                             (:comment-date . "2015-12-09T14:05:04.685Z")
+                                             (:comment-user . "redacted")))
+           (car (orgtrello-data--parse-actions alternative-data-to-test)))))
 
 (ert-deftest test-orgtrello-data-format-labels ()
   (should (equal ":red: some label\n\n:yellow: some other label"


### PR DESCRIPTION
I couldn't sync a board with org-trello and after some detective work I tracked the problem down to comment parsing. Here's the `org-trello-bug-report` data:

```
System information:
- system-type: darwin
- locale-coding-system: utf-8-unix
- emacs-version: GNU Emacs 25.0.50.8 (x86_64-apple-darwin15.0.0, NS appkit-1404.34 Version 10.11.2 (Build 15C50))
 of 2015-12-09
- org version: 8.3.2
- org-trello version: 0.7.5
- org-trello path: /Users/martin/.emacs.d/elpa/org-trello-20150905.1124/org-trello.el
```

Here's the redacted data passed to `orgtrello-data--parse-actions`.
```
[((id . "566") (idMemberCreator . "52f") (data (list (name . "ToDo") (id . "561")) (board (shortLink . "wLd") (name . "Working title") (id . "562")) (card (shortLink . "cIZ") (idShort . 16) (name . "Figure out a name") (id . "563")) (text . "Working title")) (type . "commentCard") (date . "2015-12-09T14:05:04.685Z") (memberCreator (id . "52f") (avatarHash . "5e5") (fullName . "Martin") (initials . "M") (username . "redacted")))]
```

Without my proposed change this will fail with:

```
orgtrello-data-put-entity-comment-user: Wrong type argument: listp, "566"
```

I don't know what's up. Has the Trello API changed?