### PR TITLE
Fix parsing of timestamps

### DIFF
--- a/org-trello-date.el
+++ b/org-trello-date.el
@@ -33,7 +33,7 @@
   (if org-date
       (--> (org-parse-time-string org-date)
            (apply 'encode-time it)
-           (format-time-string "%Y-%m-%dT%H:%M:%S.%3NZ" it 'universal))
+           (format-time-string "%Y-%m-%dT%H:%M:%S.%3NZ" it t))
     org-date))
 
 (defconst orgtrello-date-iso-8601-date-pattern


### PR DESCRIPTION
For some reason I get the following error on my setup when org-trello is calculating a checksum for a card with a due date:

```Invalid time zone specification: universal```

Here's my setup:
```
System information:
- system-type: darwin
- locale-coding-system: utf-8-unix
- emacs-version: GNU Emacs 25.0.50.8 (x86_64-apple-darwin15.0.0, NS appkit-1404.34 Version 10.11.2 (Build 15C50))
 of 2015-12-09
- org version: 8.3.2
- org-trello version: 0.7.5
- org-trello path: /Users/martin/.emacs.d/elpa/org-trello-20150905.1124/org-trello.el
```

If I set the ZONE to `t`, which means UTC. I get the sync working both ways. This is from the documentation for `format-time-string`.

```
The optional ZONE is omitted or nil for Emacs local time, t for
Universal Time, ‘wall’ for system wall clock time, or a string as in
```