### PR TITLE
Fix utf-8 encoding issue in issue #307

### DIFF
--- a/org-trello-query.el
+++ b/org-trello-query.el
@@ -33,8 +33,17 @@ Simply displays a success message in the minibuffer."
   "Generate the list of http authentication parameters."
   `((key . ,org-trello-consumer-key) (token . ,org-trello-access-token)))
 
+(defun orgtrello-query--decode-as-utf-8 ()
+  (let ((data (buffer-string)))
+    (erase-buffer)
+    (insert (decode-coding-string data 'utf-8))
+    (goto-char (point-min))
+    (orgtrello-log-msg orgtrello-log-debug "Decoded data to utf-8")
+    ))
+
 (defun orgtrello-query--http-parse ()
   "Parse the http response into an org-trello entity."
+  (orgtrello-query--decode-as-utf-8)
   (->> (json-read)
        orgtrello-data-parse-data))
 


### PR DESCRIPTION
By default request.el interprets the result from a request as binary.
With this change org-trello decodes the result as utf-8 before passing
using json-read to parse the response.

#307 