### PR TITLE
Make adding trello colors to `org-tag-alist` optional

### DIFF
--- a/org-trello-controller.el
+++ b/org-trello-controller.el
@@ -88,13 +88,14 @@ ARGS is not used."
      org-trello--user-logged-in (or (orgtrello-buffer-me)
                                     (orgtrello-setup-user-logged-in)))
 
-    (mapc (-partial #'add-to-list 'org-tag-alist)
-          '(("red" . ?r)
-            ("green" . ?g)
-            ("yellow" . ?y)
-            ("blue" . ?b)
-            ("purple" . ?p)
-            ("orange" . ?o)))
+    (when org-trello-add-tags
+      (mapc (-partial #'add-to-list 'org-tag-alist)
+            '(("red" . ?r)
+              ("green" . ?g)
+              ("yellow" . ?y)
+              ("blue" . ?b)
+              ("purple" . ?p)
+              ("orange" . ?o))))
     :ok))
 
 (defun orgtrello-controller-control-properties (&optional args)

--- a/org-trello.el
+++ b/org-trello.el
@@ -588,6 +588,12 @@ This does not support regular expression."
                          org-trello-files)
               (org-trello-mode))))
 
+(defcustom org-trello-add-tags t
+  "Add trello colors to org tags list?"
+  :type 'boolean
+  :require 'org-trello
+  :group 'org-trello)
+
 (orgtrello-log-msg orgtrello-log-debug "org-trello loaded!")
 
 (provide 'org-trello)

--- a/test/org-trello-test.el
+++ b/test/org-trello-test.el
@@ -313,4 +313,17 @@ System information:
                    (mock (orgtrello-log-msg orgtrello-log-info :message2) => :res)
                    (org-trello-bug-report)))))
 
+
+(ert-deftest test-org-trello-add-tags ()
+  (should (equal '()
+                 (let ((org-tag-alist '())
+                       (org-trello-add-tags nil))
+                   (orgtrello-controller-setup-properties)
+                   org-tag-alist)))
+  (should (equal '(("orange" . 111) ("purple" . 112) ("blue" . 98) ("yellow" . 121) ("green" . 103) ("red" . 114))
+                 (let ((org-tag-alist '())
+                       (org-trello-add-tags t))
+                  (orgtrello-controller-setup-properties)
+                  org-tag-alist))))
+
 (provide 'org-trello-test)


### PR DESCRIPTION
### Rapid summary

Make adding trello colors to `org-tag-alist` optional

### What issue does this fix or improve?

Currently, org-trello overrides my custom tags shortcuts which is annoying.

### Have you checked and/or added tests?

Not yet, I'm willing to write tests and will need guidance for it, but first wanted to check if this is an acceptable change.