### PR TITLE
Pte/correct json

### DIFF
--- a/org-trello-query.el
+++ b/org-trello-query.el
@@ -94,7 +94,7 @@ Simply displays a success message in the minibuffer."
           (params        (when authentication-p (orgtrello-query--authentication-params)))
           (parser        'orgtrello-query--http-parse)
           (headers       '(("Content-type" . "application/json")))
-          (data          (->> query-map orgtrello-data-entity-params json-encode))
+          (data          (encode-coding-string (->> query-map orgtrello-data-entity-params json-encode) 'utf-8))
           (success-cbck  (if success-callback success-callback 'orgtrello-query--standard-success-callback))
           (error-cbck    (if error-callback error-callback 'orgtrello-query--standard-error-callback)))
       (if (orgtrello-data-entity-sync query-map)

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -3,7 +3,7 @@
 for version in $*; do
     EMACS_NAME=emacs-$version
     # forge the right path
-    PATH=$(evm bin $EMACS_NAME):~/.evm/bin/:~/.cask/bin/:/usr/bin/:/bin
+    PATH=$(evm bin $EMACS_NAME):~/.evm/bin/:~/.cask/bin/:/usr/local/bin:/usr/bin/:/bin
     # use the emacs version
     evm use $EMACS_NAME
     # check the right emacs version is found


### PR DESCRIPTION
### Rapid summary
Avoid error when sending json encoded data with non ASCII characters

### What issue does this fix or improve?
Allow sync of cards with non ASCII characters, when the org buffer isn't encoded in UTF-8

### Have you checked and/or added tests?
All tests have been run successfully.
