### PR TITLE
Define LANG to en_US.UTF-8 to avoid mismatch on date tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ VERSION = $$(grep "^;; Version: " $(PACKAGE).el | cut -f3 -d' ')
 ARCHIVE = $(PACKAGE)-$(VERSION).tar
 EMACS ?= emacs
 CASK ?= cask
+LANG=en_US.UTF-8
 
 .PHONY: clean
 


### PR DESCRIPTION
Avoid mismatch when comparing dates with locale days of week.
This allow `make test` to pass all tests without error when user's locale isn't en_US.UTF-8
