### PR TITLE
Protect board and card name when building prefix-log.

### DIFF
--- a/org-trello-controller.el
+++ b/org-trello-controller.el
@@ -385,7 +385,9 @@ Beware, this will block Emacs as the request is synchronous."
          (point-start (point))
          (board-id (orgtrello-buffer-board-id))
          (prefix-log (format "Sync trello board '%s' to buffer '%s'..."
-                             board-name
+                             (if (stringp board-name)
+				 (replace-regexp-in-string "%" "%%" board-name)
+			       board-name)
                              buffer-name)))
     (orgtrello-deferred-eval-computation
      (list board-id buffer-name board-name point-start)
@@ -528,7 +530,9 @@ BUFFER-NAME is the actual buffer to work on."
                        (orgtrello-buffer-entry-get-full-metadata))))
          (card-name (orgtrello-data-entity-name card-meta))
          (prefix-log (format "Sync trello card '%s' to buffer '%s'..."
-                             card-name
+                             (if (stringp card-name)
+				 (replace-regexp-in-string "%" "%%" card-name)
+			       card-name)
                              buffer-name)))
     (orgtrello-deferred-eval-computation
      (list card-meta buffer-name card-name point-start)
@@ -592,7 +596,10 @@ BUFFER-NAME specifies the buffer onto which we work."
     (let* ((point-start (point))
            (card-meta (orgtrello-data-current full-meta))
            (card-name (orgtrello-data-entity-name card-meta))
-           (prefix-log (format "Archive card '%s'..." card-name)))
+           (prefix-log (format "Archive card '%s'..."
+			       (if (stringp card-name)
+			       	   (replace-regexp-in-string "%" "%%" card-name)
+			       	 card-name))))
       (orgtrello-deferred-eval-computation
        (list card-meta card-name buffer-name point-start)
        '('orgtrello-controller--archive-that-card


### PR DESCRIPTION
Replace the percent sign (%) in the names of cards or cards to avoid an error message when `orgtrello-log-msg` is called.
I started `make test` and all the tests are correct, but I did not find how to add new ones for the current case.

ex:
prepare a card with text as below
```
* a card with a percentage as in 45%
Some text ...
```
try adding a comment with `C-c o C`, type some text and validate with` C-c C-c`
You have the following error message:
`` `
org-trello - Add a comment on the card '5abac66544c84eb1a898082e' ... FAILED. Error: ("Not enough arguments for format string" error)
`` `

This patch corrects this behavior.