### PR TITLE
Ensure that the _macro_ (lexical-let ...) is defined during compile.

### DIFF
--- a/org-trello-buffer.el
+++ b/org-trello-buffer.el
@@ -21,6 +21,7 @@
 ;;; Commentary:
 ;;; Code:
 
+(eval-when-compile (require 'cl)) ;; lexical-let
 (require 'org-trello-setup)
 (require 'org-trello-utils)
 (require 'org-trello-log)

--- a/org-trello-controller.el
+++ b/org-trello-controller.el
@@ -21,6 +21,7 @@
 ;;; Commentary:
 ;;; Code:
 
+(eval-when-compile (require 'cl)) ;; lexical-let
 (require 'org-trello-setup)
 (require 'org-trello-log)
 (require 'org-trello-buffer)

--- a/org-trello-proxy.el
+++ b/org-trello-proxy.el
@@ -30,6 +30,7 @@
 ;;; Commentary:
 ;;; Code:
 
+(eval-when-compile (require 'cl)) ;; lexical-let
 (require 'org-trello-log)
 (require 'org-trello-setup)
 (require 'org-trello-query)


### PR DESCRIPTION
THANK YOU very much for writing and maintaining this. I hope to get some use out of it next month.

### Rapid summary

I found that, like the user in issue #378, I could install and setup, but not sync due to a void function definition. I poked around and noticed that the offending functions all used the lexical-let macro, googled that and found a suggested solution that made sense. When I added the line to my ~/emacs.d/elpa/org-trello/*.el files and re-compiled the directory, the compile errors vanished and I could sync to trello. I assume that your (and perhaps most user's) emacs init file loads the lexical-let macro at some point and mine (and the other impacted user's) doesn't.

-----
lexical-let is not defined in cl-lib, only in cl.
See https://emacs.stackexchange.com/questions/18726/void-function-lexical-let
-----

### What issue does this fix or improve?
This addresses the void functions that appear to be an installation problem in Issue #378. See my comment at the bottom there.

### Have you checked and/or added tests?
No, sorry. "It runs on my PC" :-)
I'm not sure that I could do tests justice, or even make your project properly. I'm no kind of e-lisp programmer. I just read a lot and puzzle some things out occasionally. Got lucky this time.
