### PR TITLE
Fix defconst org-trello--version to "0.8.1" to match header comment.

### DIFF
--- a/org-trello.el
+++ b/org-trello.el
@@ -114,7 +114,7 @@ Please consider upgrading Emacs." emacs-version)
 (require 'json)
 (require 'parse-time)
 
-(defconst org-trello--version "0.8.0" "Current org-trello version installed.")
+(defconst org-trello--version "0.8.1" "Current org-trello version installed.")
 
 
 


### PR DESCRIPTION
### Rapid summary
I noticed that M-x org-trello-version returned "0.8.0" despite installing latest from MELPA. I found that the org-trello.el file header comment said 0.8.1, but the variable was still "0.8.0". I have updated it.

### What issue does this fix or improve?
M-x org-trello-version returned old version number.

### Have you checked and/or added tests?
No. One character change. I'm running from MELPA but editing from GitHub.