### PR TITLE
Fix reference to org-file-properties

### DIFF
--- a/org-trello-buffer.el
+++ b/org-trello-buffer.el
@@ -750,8 +750,8 @@ Make it a hashmap with key :level,  :keyword,  :name and their respective value.
 
 (defun orgtrello-buffer-org-file-properties ()
   "Compute the org buffer's file properties."
-  (let ((org-trello-file-properties org-file-properties))
-    org-trello-file-properties))
+  (cond ((boundp 'org-file-properties) org-file-properties)
+        ((boundp 'org-keyword-properties) org-keyword-properties)))
 
 (defun orgtrello-buffer-org-map-entries (fn-to-execute)
   "Execute for each heading the FN-TO-EXECUTE."

--- a/org-trello-controller.el
+++ b/org-trello-controller.el
@@ -1266,7 +1266,7 @@ DATA is a list of (card-id comment-id comment-text buffername)."
 (defun orgtrello-controller-do-cleanup-from-buffer (&optional globally-flag)
   "Clean org-trello data in current buffer.
 When GLOBALLY-FLAG is not nil, remove also local entities properties."
-  (when org-file-properties
+  (when (orgtrello-buffer-org-file-properties)
     (orgtrello-controller--remove-properties-file
      org-trello--org-keyword-trello-list-names
      org-trello--hmap-users-name-id

--- a/test/org-trello-action-test.el
+++ b/test/org-trello-action-test.el
@@ -14,7 +14,21 @@
 "
                   (let ((org-file-properties))
                     (orgtrello-action-reload-setup)
-                    org-file-properties)))))
+                    (orgtrello-buffer-org-file-properties))))))
+
+(ert-deftest test-orgtrello-action-reload-setup-2 ()
+  (should (equal '(("foo" . "10") ("bar" . "20"))
+                 (orgtrello-tests-with-temp-buffer
+                  ":PROPERTIES:
+#+PROPERTY: foo 10
+#+PROPERTY: bar 20
+:END
+
+* heading
+"
+                  (let ((org-keyword-properties))
+                    (orgtrello-action-reload-setup)
+                    (orgtrello-buffer-org-file-properties))))))
 
 (ert-deftest test-orgtrello-action--execute-controls ()
   (should (equal '(:ok) (orgtrello-action--execute-controls '((lambda (e) :ok)))))


### PR DESCRIPTION
Since org version 9.4, the variable got renamed to `org-keyword-properties`. To
keep it compatible with old version though,
`orgtrello-buffer-org-file-properties` function checs for the right variable
prior to returning its value.

This commit also fixes another call to that variable without passing by the
function `orgtrello-buffer-org-file-properties`.

Related #403
Related #402
