### PR TITLE
Fixed small typo entity sync command.

### DIFF
--- a/org-trello-proxy.el
+++ b/org-trello-proxy.el
@@ -135,7 +135,7 @@ All maps are indexed by trello or marker id."
                                     (progn ;; not present, update with trello id
                                       (orgtrello-buffer-write-properties-at-pt
                                        entry-new-id)
-                                      (format "Newly entity '%s' with id '%s' synced!"
+                                      (format "New entity '%s' with id '%s' synced!"
                                               entity-name
                                               entry-new-id)))))
               (let* ((updates (orgtrello-proxy--update-entities-adjacencies


### PR DESCRIPTION
Hello,

Can you please provide the following information?
Thanks in advance

### Rapid summary
There was a small typo in the entity sync message, I've fixed it. 

### What issue does this fix or improve?
Fixes typo.

### Have you checked and/or added tests?
No, I'm not actually familiar with ert unfortunately and thought given the smallness of the change this would likely not be necessary.

Thanks for the great package! Afraid I've never submitted a pull request before so apologies if I've screwed anything up.

Cheers,

Charlie