### PR TITLE
Conditionally load cl-lib if Emacs recent enough

### DIFF
--- a/org-trello-buffer.el
+++ b/org-trello-buffer.el
@@ -21,7 +21,9 @@
 ;;; Commentary:
 ;;; Code:
 
-(eval-when-compile (require 'cl)) ;; lexical-let
+(if (version< emacs-version "27")
+    (eval-when-compile (require 'cl))
+    (eval-when-compile (require 'cl-lib)))
 (require 'org-trello-setup)
 (require 'org-trello-utils)
 (require 'org-trello-log)

--- a/org-trello-controller.el
+++ b/org-trello-controller.el
@@ -21,7 +21,10 @@
 ;;; Commentary:
 ;;; Code:
 
-(eval-when-compile (require 'cl)) ;; lexical-let
+(if (version< emacs-version "27")
+    (eval-when-compile (require 'cl))
+    (eval-when-compile (require 'cl-lib)))
+
 (require 'org-trello-setup)
 (require 'org-trello-log)
 (require 'org-trello-buffer)

--- a/org-trello-proxy.el
+++ b/org-trello-proxy.el
@@ -30,7 +30,9 @@
 ;;; Commentary:
 ;;; Code:
 
-(eval-when-compile (require 'cl)) ;; lexical-let
+(if (version< emacs-version "27")
+    (eval-when-compile (require 'cl))
+    (eval-when-compile (require 'cl-lib)))
 (require 'org-trello-log)
 (require 'org-trello-setup)
 (require 'org-trello-query)

--- a/org-trello.el
+++ b/org-trello.el
@@ -107,7 +107,7 @@ Please consider upgrading Emacs." emacs-version)
 
 (when (version< emacs-version "24") (error org-trello-error-install-msg))
 
-(require 'cl)
+(if (version< emacs-version "27") (require 'cl) (require 'cl-lib))
 
 ;; Dependency on internal Emacs libs
 (require 'org)


### PR DESCRIPTION

### Rapid summary
The `cl` package is officially deprecated in Emacs 27, and was causing issues for me upon startup. I added some code to conditionally load `cl-lib` instead of `cl` to retain backwards compatibility. 

### What issue does this fix or improve?
If running Emacs 27 or newer, `cl-lib` will be loaded instead of `cl`.

### Have you checked and/or added tests?
I ran the test suite, everything seemed to pass. Manually loaded the package as well and did some testing and didn't find anything out of the ordinary. As I understand `cl-lib` is backwards compatible with `cl`.
