### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/Cask
+++ b/Cask
@@ -24,7 +24,6 @@
        "README.md")
 
 (development
- (depends-on "dash-functional")
  (depends-on "dash")
  (depends-on "ert-runner")
  (depends-on "undercover")

--- a/org-trello-action.el
+++ b/org-trello-action.el
@@ -24,7 +24,7 @@
 (require 'org)
 (require 'org-trello-setup)
 (require 'org-trello-log)
-(require 'dash-functional)
+(require 'dash)
 (require 's)
 
 (defalias 'orgtrello-action-reload-setup 'org-set-regexps-and-options

--- a/org-trello-buffer.el
+++ b/org-trello-buffer.el
@@ -32,7 +32,7 @@
 (require 'org-trello-cbx)
 (require 'org-trello-backend)
 (require 'org-trello-date)
-(require 'dash-functional)
+(require 'dash)
 
 (defun orgtrello-buffer-global-properties-region ()
   "Compute the global properties from the buffer.

--- a/org-trello-controller.el
+++ b/org-trello-controller.el
@@ -36,7 +36,7 @@
 (require 'org-trello-input)
 (require 'org-trello-proxy)
 (require 'org-trello-deferred)
-(require 'dash-functional)
+(require 'dash)
 (require 's)
 
 (defun orgtrello-controller-log-success (prefix-log)

--- a/org-trello-data.el
+++ b/org-trello-data.el
@@ -26,7 +26,7 @@
 (require 'org-trello-hash)
 (require 's)
 (require 'json)
-(require 'dash-functional)
+(require 'dash)
 
 (defun orgtrello-data-merge-2-lists-without-duplicates (a-list b-list)
   "Merge the 2 lists A-LIST and B-LIST together without duplicates."

--- a/org-trello-pkg.el
+++ b/org-trello-pkg.el
@@ -1,6 +1,6 @@
 (define-package "org-trello" "0.8.2" "Minor mode to synchronize org-mode buffer and trello board"
-  '((request-deferred "0.2.0")
+  '((emacs "24.3")
+    (request-deferred "0.2.0")
     (deferred "0.4.0")
     (s "1.11.0")
-    (dash-functional "2.12.1")
-    (dash "2.12.1")))
+    (dash "2.18.0")))

--- a/org-trello.el
+++ b/org-trello.el
@@ -5,7 +5,7 @@
 ;; Author: Antoine R. Dumont (@ardumont) <antoine.romain.dumont@gmail.com>
 ;; Maintainer: Antoine R. Dumont (@ardumont) <antoine.romain.dumont@gmail.com>
 ;; Version: 0.8.2
-;; Package-Requires: ((dash "2.12.1") (dash-functional "2.12.1") (s "1.11.0") (deferred "0.4.0") (request-deferred "0.2.0"))
+;; Package-Requires: ((emacs "24.3") (dash "2.18.0") (s "1.11.0") (deferred "0.4.0") (request-deferred "0.2.0"))
 ;; Keywords: org-mode trello sync org-trello
 ;; URL: https://github.com/org-trello/org-trello
 

--- a/test/org-trello-backend-test.el
+++ b/test/org-trello-backend-test.el
@@ -1,5 +1,5 @@
 (require 'org-trello-backend)
-(require 'dash-functional)
+(require 'dash)
 (require 'ert)
 (require 'el-mock)
 

--- a/test/org-trello-query-test.el
+++ b/test/org-trello-query-test.el
@@ -289,7 +289,7 @@
                    (orgtrello-query-http-trello :query-map :sync :success-callback :error-callback)))))
 
 (ert-deftest test-orgtrello-query--standard-error-callback ()
-  (should (equal "org-trello - Detailed response: #s(request-response nil nil nil \"some error thrown\" nil nil nil nil nil nil nil nil nil)"
+  (should (equal "org-trello - Detailed response: #s(request-response nil nil nil \"some error thrown\" nil nil nil nil nil nil nil nil)"
                  (let ((orgtrello-log-level orgtrello-log-debug))
                    (orgtrello-query--standard-error-callback :response (make-request-response :error-thrown "some error thrown"))))))
 


### PR DESCRIPTION
### Rapid summary

Dash 2.18.0 now subsumes `dash-functional`, which is deprecated; see https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218

### What issue does this fix or improve?

It removes this package's dependency on the now deprecated `dash-functional` library, and replaces it with the newest version of `dash` which now includes all of the old definitions from `dash-functional`.

While in the area, this PR also formalises the existing dependency on Emacs `24.3+` in the package's `Package-Requires` header.

### Have you checked and/or added tests?

CI passes after a tweak to `test-orgtrello-query--standard-error-callback`.  I can't tell if the test failure is related to this PR.