### PR TITLE
Support for limited load of cards by creation date.

### DIFF
--- a/org-trello-api.el
+++ b/org-trello-api.el
@@ -93,12 +93,20 @@ When UNDO-FLAG is set, trigger the undo computation."
   "Retrieve the memberships from a BOARD-ID."
   (orgtrello-api-make-query "GET" (format "/boards/%s/members" board-id)))
 
+(defun orgtrello-get-predefined-card-filters-for-request ()
+  (list
+   (if (not (s-blank? org-trello-mode-limit-fetch-since))
+       (cons "since" org-trello-mode-limit-fetch-since))
+   (if (not (s-blank? org-trello-mode-limit-fetch-before))
+       (cons "before" org-trello-mode-limit-fetch-before))))
+
 (defun orgtrello-api-get-cards (board-id)
   "Create a cards retrieval from the board with BOARD-ID query."
   (orgtrello-api-make-query
    "GET"
    (format "/boards/%s/cards" board-id)
-   '(("actions" .  "commentCard")
+   `(("actions" .  "commentCard")
+     ,@(orgtrello-get-predefined-card-filters-for-request)
      ("fields" .
       "closed,desc,due,idBoard,idChecklists,idList,idMembers,name,pos"))))
 
@@ -107,9 +115,10 @@ When UNDO-FLAG is set, trigger the undo computation."
   (orgtrello-api-make-query
    "GET"
    (format "/boards/%s/cards" board-id)
-   '(("actions" .  "commentCard")
+   `(("actions" .  "commentCard")
      ("checklists" . "all")
      ;;("checkItemStates" . "true")
+     ,@(orgtrello-get-predefined-card-filters-for-request)
      ("filter" . "open")
      ("fields" .
       "closed,desc,due,idBoard,idList,idMembers,labels,name,pos"))))
@@ -119,7 +128,8 @@ When UNDO-FLAG is set, trigger the undo computation."
   (orgtrello-api-make-query
    "GET"
    (format "/boards/%s/cards" board-id)
-   '(("filter" . "closed")
+   `(("filter" . "closed")
+     ,@(orgtrello-get-predefined-card-filters-for-request)
      ("fields" .
       "closed,desc,due,idBoard,idList,idMembers,labels,name,pos"))))
 

--- a/org-trello.el
+++ b/org-trello.el
@@ -538,6 +538,16 @@ opens new issue in org-trello's github tracker."
   :type 'hook
   :group 'org-trello)
 
+(defcustom org-trello-mode-limit-fetch-since ""
+  "During sync from trello to org fetch only cards created since given date in ISO ISO 8601 format."
+  :type 'string
+  :group 'org-trello)
+
+(defcustom org-trello-mode-limit-fetch-before ""
+  "During sync from trello to org fetch only cards created before given date in ISO ISO 8601 format."
+  :type 'string
+  :group 'org-trello)
+
 (defvar org-trello-mode-on-hook)
 (setq org-trello-mode-on-hook nil) ;; for dev
 (add-hook 'org-trello-mode-on-hook 'orgtrello-controller-mode-on-hook-fn)


### PR DESCRIPTION
### Rapid summary

This solves #385 . Allows partial synchronization with trello board based on date of cards created.

### What issue does this fix or improve?

So here is the solution for almost any size of trello board. This PR adds custom variables that define time period from which cards will be fetched.

Trello API limits amount of cards that could be fetched to 1000. But you usually don't need all of it. You work with few cards from current month or two. So now you can go to `M-x customize-group` then `org-trello` and set `Org Trello Mode Limit Fetch Since` to, for example, '2022-01-01'. Then you go to your trello associated buffer and do `C-u M-x org-trello-sync-buffer` and it fetches only cards older then 2022-01-01.

Also you can have some "reference" cards with checklists you use often, but such cards could be created long time ago. So you try to figure out the dates of creation of needed cards. Then, for example, you customize `Org Trello Mode Limit Fetch Since` to 2018-01-01 and `Org Trello Mode Limit Fetch Before` to 2018-01-31. Then you aplly customizations and go to your org buffer, then you sync via `C-u M-x org-trello-sync-buffer`. And now you also have needed cards added from that period.

If you have multiple Trello boards you can use .dir-locals.el to set fetch limits for each one. To fetch all cards as usual, just set variables `Org Trello Mode Limit Fetch Before` and `Org Trello Mode Limit Fetch Before` to blank string "".

### Have you checked and/or added tests?

Tests were done for:
- creating cards
- modifying cards
- syncing all board
- single card syncing


